### PR TITLE
Fix #2369 Images are replaced by [object Module] instead of the actua…

### DIFF
--- a/src/builder/webpack-rules.js
+++ b/src/builder/webpack-rules.js
@@ -33,7 +33,8 @@ module.exports = function () {
                             '?[hash]'
                         );
                     },
-                    publicPath: Config.resourceRoot
+                    publicPath: Config.resourceRoot,
+                    esModule: false
                 }
             },
 


### PR DESCRIPTION
Since file-loader 5.0 the esModule option has changed default and doesn't import images correctly with webpack 5

You can find more info there 
https://github.com/webpack-contrib/file-loader/commit/98a6c1d3569759c297e29bfc0b20ef552b50d373
And there
https://stackoverflow.com/questions/59070216/webpack-file-loader-outputs-object-module