### PR TITLE
Change default BrowserSync Proxy to folder name

### DIFF
--- a/docs/browsersync.md
+++ b/docs/browsersync.md
@@ -1,7 +1,12 @@
 # Browsersync
 
 Browsersync will automatically monitor your files for changes, and inject any changes into the browser - all without requiring a manual refresh. 
-You can enable support by calling the `mix.browserSync()` command, like so:
+You can enable support by calling the Browsersync command, like so:
+
+```js
+mix.browserSync();
+```
+The proxy will automatically default to your project's folder name and will assume a ```.test``` TLD in line with the default Laravel Vale naming convention. You can customise the domain by passing a string to the Browsersync command:
 
 ```js
 mix.browserSync('my-domain.test');
@@ -9,7 +14,7 @@ mix.browserSync('my-domain.test');
 
 If you need to pass configuration options to the underlying Browsersync, instead pass an object.
 
-```
+```js
 mix.browserSync({
     proxy: 'my-domain.test',
 });

--- a/src/components/BrowserSync.js
+++ b/src/components/BrowserSync.js
@@ -43,7 +43,7 @@ class BrowserSync {
         let defaultConfig = {
             host: 'localhost',
             port: 3000,
-            proxy: process.cwd().split('/').pop() + '.test',
+            proxy: process.cwd().replaceAll('\\', '/').split('/').pop() + '.test',
             files: [
                 'app/**/*.php',
                 'resources/views/**/*.php',

--- a/src/components/BrowserSync.js
+++ b/src/components/BrowserSync.js
@@ -1,3 +1,5 @@
+let path = require('path');
+
 class BrowserSync {
     /**
      * Required dependencies for the component.
@@ -43,7 +45,7 @@ class BrowserSync {
         let defaultConfig = {
             host: 'localhost',
             port: 3000,
-            proxy: process.cwd().replace(/\\/g, '/').split('/').pop() + '.test',
+            proxy: `${path.basename(process.cwd())}.test`,
             files: [
                 'app/**/*.php',
                 'resources/views/**/*.php',

--- a/src/components/BrowserSync.js
+++ b/src/components/BrowserSync.js
@@ -43,7 +43,7 @@ class BrowserSync {
         let defaultConfig = {
             host: 'localhost',
             port: 3000,
-            proxy: process.cwd().replaceAll('\\', '/').split('/').pop() + '.test',
+            proxy: process.cwd().replace(/\\/g, '/').split('/').pop() + '.test',
             files: [
                 'app/**/*.php',
                 'resources/views/**/*.php',

--- a/src/components/BrowserSync.js
+++ b/src/components/BrowserSync.js
@@ -43,7 +43,7 @@ class BrowserSync {
         let defaultConfig = {
             host: 'localhost',
             port: 3000,
-            proxy: 'app.test',
+            proxy: process.cwd().split('/').pop() + '.test',
             files: [
                 'app/**/*.php',
                 'resources/views/**/*.php',

--- a/test/features/browsersync.js
+++ b/test/features/browsersync.js
@@ -45,7 +45,7 @@ test('it injects the snippet in the right place', t => {
 });
 
 test('it configures Browsersync proxy', t => {
-    t.is(browserSyncConfig().proxy, 'app.test', 'sets default proxy');
+    t.is(browserSyncConfig().proxy, 'laravel-mix.test', 'sets default proxy');
     t.is(
         browserSyncConfig('example.domain').proxy,
         'example.domain',

--- a/test/features/browsersync.js
+++ b/test/features/browsersync.js
@@ -1,4 +1,5 @@
 import test from 'ava';
+import path from 'path';
 import mockRequire from 'mock-require';
 
 import BrowserSync from '../../src/components/BrowserSync.js';
@@ -45,7 +46,7 @@ test('it injects the snippet in the right place', t => {
 });
 
 test('it configures Browsersync proxy', t => {
-    t.is(browserSyncConfig().proxy, 'laravel-mix.test', 'sets default proxy');
+    t.is(browserSyncConfig().proxy, `${path.basename(process.cwd())}.test`, 'sets default proxy');
     t.is(
         browserSyncConfig('example.domain').proxy,
         'example.domain',


### PR DESCRIPTION
changes the default proxy to the project root folder name followed by ".test". Inspired by Laravel Vale's domain naming convetion.

before

```js
let path = require("path");

...

mix.broserSync({
    proxy: path.basename(__dirname) + '.test',
})
```

after

```js
mix.browserSync()
```