### PR TITLE
Only build one time in CustomTasksPlugin (#1053)

### DIFF
--- a/src/tasks/ConcatenateFilesTask.js
+++ b/src/tasks/ConcatenateFilesTask.js
@@ -24,7 +24,7 @@ class ConcatenateFilesTask extends Task {
      * Handle when a relevant source file is changed.
      */
     onChange(updatedFile) {
-        this.merge();
+        return this.merge();
     }
 }
 

--- a/src/tasks/Task.js
+++ b/src/tasks/Task.js
@@ -16,14 +16,18 @@ class Task {
      * Watch all relevant files for changes.
      *
      * @param {boolean} usePolling
+     * @param {function(Task)} onFileChange Will be called on every file that changes
      */
-    watch(usePolling = false) {
+    watch(usePolling = false, onFileChange = Function()) {
         if (this.isBeingWatched) return;
 
         let files = this.files.get();
         let watcher = chokidar
             .watch(files, { usePolling, persistent: true })
-            .on('change', this.onChange.bind(this));
+            .on('change', async file => {
+                await Promise.resolve(this.onChange(file));
+                onFileChange(this);
+            });
 
         // Workaround for issue with atomic writes.
         // See https://github.com/paulmillr/chokidar/issues/591

--- a/src/webpackPlugins/CustomTasksPlugin.js
+++ b/src/webpackPlugins/CustomTasksPlugin.js
@@ -18,22 +18,18 @@ class CustomTasksPlugin {
     apply(compiler) {
         let firstRun = true;
         compiler.hooks.done.tapAsync(this.constructor.name, (stats, callback) => {
+            // Only run all tasks on first run
             if (firstRun) {
                 firstRun = false;
                 this.runTasks(stats).then(async () => {
-                    if (this.mix.components.get('version') && !this.mix.isUsing('hmr')) {
-                        this.applyVersioning();
-                    }
-
-                    if (this.mix.inProduction()) {
-                        await this.minifyAssets();
-                    }
+                    await this.afterChange();
 
                     if (this.mix.isWatching()) {
-                        this.mix.tasks.forEach(task => task.watch(this.mix.isPolling()));
+                        this.mix.tasks.forEach(task =>
+                            task.watch(this.mix.isPolling(), this.afterChange.bind(this))
+                        );
                     }
 
-                    this.mix.manifest.refresh();
                     callback();
                 });
             } else {
@@ -95,9 +91,10 @@ class CustomTasksPlugin {
 
     /**
      * Minify the given asset file.
+     * @param {Task} task If specified, only assets of this task will be minified
      */
-    async minifyAssets() {
-        const assets = collect(this.mix.tasks)
+    async minifyAssets(task = null) {
+        const assets = collect(task ? [task] : this.mix.tasks)
             .where('constructor.name', '!==', 'VersionFilesTask')
             .flatMap(({ assets }) => assets);
 
@@ -124,6 +121,25 @@ class CustomTasksPlugin {
         collect(this.mix.manifest.get()).each((value, key) =>
             this.mix.manifest.hash(key)
         );
+    }
+
+    /**
+     * Performs manifest and minification updates on files after running tasks
+     * @param {Task|null} task If specified, only files for this task will be minified
+     * @return {Promise<void>}
+     */
+    async afterChange(task = null) {
+        if (this.mix.components.get('version') && !this.mix.isUsing('hmr')) {
+            this.applyVersioning();
+        }
+
+        if (this.mix.inProduction()) {
+            // Minify task assets
+            await this.minifyAssets(task);
+        }
+
+        // Rewrite manifest file
+        this.mix.manifest.refresh();
     }
 }
 

--- a/src/webpackPlugins/CustomTasksPlugin.js
+++ b/src/webpackPlugins/CustomTasksPlugin.js
@@ -16,23 +16,29 @@ class CustomTasksPlugin {
      * @param {import("webpack").Compiler} compiler
      */
     apply(compiler) {
+        let firstRun = true;
         compiler.hooks.done.tapAsync(this.constructor.name, (stats, callback) => {
-            this.runTasks(stats).then(async () => {
-                if (this.mix.components.get('version') && !this.mix.isUsing('hmr')) {
-                    this.applyVersioning();
-                }
+            if (firstRun) {
+                firstRun = false;
+                this.runTasks(stats).then(async () => {
+                    if (this.mix.components.get('version') && !this.mix.isUsing('hmr')) {
+                        this.applyVersioning();
+                    }
 
-                if (this.mix.inProduction()) {
-                    await this.minifyAssets();
-                }
+                    if (this.mix.inProduction()) {
+                        await this.minifyAssets();
+                    }
 
-                if (this.mix.isWatching()) {
-                    this.mix.tasks.forEach(task => task.watch(this.mix.isPolling()));
-                }
+                    if (this.mix.isWatching()) {
+                        this.mix.tasks.forEach(task => task.watch(this.mix.isPolling()));
+                    }
 
-                this.mix.manifest.refresh();
+                    this.mix.manifest.refresh();
+                    callback();
+                });
+            } else {
                 callback();
-            });
+            }
         });
     }
 

--- a/src/webpackPlugins/CustomTasksPlugin.js
+++ b/src/webpackPlugins/CustomTasksPlugin.js
@@ -1,5 +1,6 @@
 let Log = require('../Log');
 let collect = require('collect.js');
+const { debounce } = require('lodash');
 
 class CustomTasksPlugin {
     /**
@@ -26,7 +27,10 @@ class CustomTasksPlugin {
 
                     if (this.mix.isWatching()) {
                         this.mix.tasks.forEach(task =>
-                            task.watch(this.mix.isPolling(), this.afterChange.bind(this))
+                            task.watch(
+                                this.mix.isPolling(),
+                                debounce(this.afterChange.bind(this), 100)
+                            )
                         );
                     }
 


### PR DESCRIPTION
This solves an issue with unnecessary reloads with BrowserSync: https://github.com/JeffreyWay/laravel-mix/issues/1053#issuecomment-826368904

`CustomTasksPlugin` runs all post-build tasks again for every rebuild, no matter if it was not initiated from its own watchers. All files built using `.babel()`, `.scripts()`, `.combine()`, `.styles()` and `.copy()` are being rebuilt every time, causing unnecessary BrowserSync full page reloads.

For example, if you have a Vue app built with `.js()`, but also some old scripts built with `.babel()`. When changing something in the Vue app, it should apply a Hot Module Replacement without reloading the page, but since the `.js` files built with `.babel()` are also rebuilt, BrowserSync detects those changes and triggers a reload.

With this PR, CustomTasksPlugin only builds files the first time or when their watchers are triggered.