### PR TITLE
[Fix] watch-poll command detection

### DIFF
--- a/src/Mix.js
+++ b/src/Mix.js
@@ -182,7 +182,9 @@ class Mix {
      * Determine if polling is used for file watching
      */
     isPolling() {
-        return this.isWatching() && process.argv.includes('--watch-poll');
+        const hasPollingOption = process.argv.some((arg) => arg.includes('--watch-options-poll'));
+
+        return this.isWatching() && hasPollingOption;
     }
 
     /**


### PR DESCRIPTION
# Problem:

The new `mix watch -- --watch-options-poll=1000` command is not starting the watch with the polling option.

In Laravel Mix v6, the watch command as changed from `--watch-poll` to `--watch-options-poll={POLLING_INTERVAL}` and the current validation to test if `Mix` should use the polling options isn’t really detecting it.

# How to reproduce:

Just try to run the new default mix watch poll execution - `npm run watch-poll` or `npx mix watch -- --watch-options-poll=1000` - then change a file that has been “watched”.

# Solution:

As the command changed to receive the polling interval direct from the command, the current validation (`process.argv.includes('--watch-poll')`) actually doesn’t detect the option, because the `.includes()` method from JS Array needs to test exactly the indexes and the current validation should be prepared to test all the values passed by the developer.

Therefore, to simplify, I loop through all the `process.argv` values passed by the Node execution to test if one of them has the `—watch-options-poll` “key”.

Found by my teammate: [Irineu Junior](https://github.com/irineujunior)

This PR maybe closes the issue [#3049](https://github.com/JeffreyWay/laravel-mix/issues/3049)