### PR TITLE
Fix HMR usage for *.test domains

### DIFF
--- a/src/builder/webpack-default.js
+++ b/src/builder/webpack-default.js
@@ -58,7 +58,7 @@ module.exports = function (mix) {
             static: path.resolve(mix.config.publicPath),
             historyApiFallback: true,
             compress: true,
-            allowedHosts: 'auto'
+            allowedHosts: 'all'
         },
 
         watchOptions: {


### PR DESCRIPTION
Its common for people using Homestead to use urls like myapp.test. The "auto" option does not allow such domains. Since this is meant to be development only there should be no issue with allowing all hosts to access HMR resources as was previously the case.

Fixes #3074