### PR TITLE
Silence ESM bundler warnings for Vue 3

### DIFF
--- a/src/Mix.js
+++ b/src/Mix.js
@@ -33,7 +33,7 @@ class Mix {
         this.dispatcher = new Dispatcher();
         this.manifest = new Manifest();
         this.paths = new Paths();
-        this.registrar = new ComponentRegistrar();
+        this.registrar = new ComponentRegistrar(this);
         this.webpackConfig = new WebpackConfig(this);
         this.hot = new HotReloading(this);
         this.resolver = new Resolver();
@@ -182,7 +182,9 @@ class Mix {
      * Determine if polling is used for file watching
      */
     isPolling() {
-        const hasPollingOption = process.argv.some((arg) => arg.includes('--watch-options-poll'));
+        const hasPollingOption = process.argv.some(arg =>
+            arg.includes('--watch-options-poll')
+        );
 
         return this.isWatching() && hasPollingOption;
     }

--- a/src/components/Component.js
+++ b/src/components/Component.js
@@ -1,0 +1,60 @@
+/**
+ * @abstract
+ * @internal (for now)
+ **/
+class Component {
+    /** Whether or not to automatically register this component */
+    passive = false;
+
+    /** Whether or not this component requires dependency reloading */
+    requiresReload = false;
+
+    /**
+     *
+     * @param {import("../Mix")} mix
+     */
+    constructor(mix) {
+        this.context = mix;
+    }
+
+    /**
+     * Specifiy one or more dependencies that must
+     * be installed for this component to work
+     *
+     * @protected
+     * @returns {import("../Dependencies").Dependency[]}
+     **/
+    dependencies() {
+        return [];
+    }
+
+    /**
+     * Add rules to the webpack config
+     *
+     * @returns {import('webpack').RuleSetRule[]}
+     **/
+    webpackRules() {
+        return [];
+    }
+
+    /**
+     * Add plugins to the webpack config
+     *
+     * @returns {import('webpack').WebpackPluginInstance[]}
+     **/
+    webpackPlugins() {
+        return [];
+    }
+
+    /**
+     * Update the webpack config
+     *
+     * @param {import('webpack').Configuration} config
+     * @returns {import('webpack').Configuration}
+     **/
+    webpackConfig(config) {
+        return config;
+    }
+}
+
+module.exports.Component = Component;

--- a/src/components/ComponentRegistrar.js
+++ b/src/components/ComponentRegistrar.js
@@ -1,12 +1,14 @@
 let Assert = require('../Assert');
 let Dependencies = require('../Dependencies');
 let mergeWebpackConfig = require('../builder/MergeWebpackConfig');
+const { Component } = require('./Component');
 
 let components = [
     'JavaScript',
     'Preact',
     'React',
     'Coffee',
+    'Define',
     'TypeScript',
     'Less',
     'Sass',
@@ -42,7 +44,13 @@ let components = [
 ];
 
 class ComponentRegistrar {
-    constructor() {
+    /**
+     *
+     * @param {import('../Mix')} [mix]
+     */
+    constructor(mix) {
+        this.mix = mix || global.Mix;
+
         this.components = {};
     }
 
@@ -58,10 +66,22 @@ class ComponentRegistrar {
     /**
      * Install a component.
      *
-     * @param {Component} Component
+     * @param {import("../../types/component").Component} ComponentDefinition
      */
-    install(Component) {
-        let component = typeof Component === 'function' ? new Component() : Component;
+    install(ComponentDefinition) {
+        /** @type {import("../../types/component").Component} */
+        let component;
+
+        // If we're extending from the internal `Component` class then we provide the mix API object
+        if (Component.isPrototypeOf(ComponentDefinition)) {
+            // @ts-ignore
+            // This API is not finalized which is why we've restricted to to the internal component class for now
+            component = new ComponentDefinition(this.mix);
+        } else if (typeof ComponentDefinition === 'function') {
+            component = new ComponentDefinition();
+        } else {
+            component = ComponentDefinition;
+        }
 
         this.registerComponent(component);
 

--- a/src/components/Define.js
+++ b/src/components/Define.js
@@ -1,0 +1,59 @@
+const webpack = require('webpack');
+const { Component } = require('./Component');
+
+/** @typedef {undefined | null | string | number | bigint | boolean} CodeValuePrimitive */
+/** @typedef {() => CodeValuePrimitive} LazyCodeValue */
+/** @typedef {CodeValuePrimitive | LazyCodeValue} CodeValue */
+
+class Define extends Component {
+    /**
+     * @type {Record<string, CodeValue>}
+     * @internal
+     **/
+    definitions = {};
+
+    /**
+     *
+     * @param {Record<string, CodeValue>} definitions
+     */
+    register(definitions) {
+        this.definitions = {
+            ...this.definitions,
+            ...definitions
+        };
+    }
+
+    /** @internal */
+    get defaults() {
+        return {
+            'import.meta.env.PROD': () => this.context.api.inProduction(),
+            'import.meta.env.DEV': () => !this.context.api.inProduction()
+        };
+    }
+
+    /**
+     * @param {Record<string, CodeValue>} definitions
+     */
+    resolve(definitions) {
+        for (const [key, value] of Object.entries(definitions)) {
+            if (typeof value === 'function') {
+                definitions[key] = value();
+            }
+        }
+
+        return definitions;
+    }
+
+    webpackPlugins() {
+        return [
+            new webpack.DefinePlugin(
+                this.resolve({
+                    ...this.defaults,
+                    ...this.definitions
+                })
+            )
+        ];
+    }
+}
+
+module.exports = Define;

--- a/src/components/Vue.js
+++ b/src/components/Vue.js
@@ -48,6 +48,8 @@ class Vue {
 
         Mix.globalStyles = this.options.globalStyles;
         Mix.extractingStyles = !!this.options.extractStyles;
+
+        this.addDefines();
     }
 
     /**
@@ -189,6 +191,22 @@ class Vue {
                 : '/css/vue-styles.css';
 
         return fileName.replace(Config.publicPath, '').replace(/^\//, '');
+    }
+
+    /**
+     * Determine the extract file name.
+     *
+     * @internal
+     */
+    addDefines() {
+        if (this.version === 2) {
+            return;
+        }
+
+        this._mix.api.define({
+            __VUE_OPTIONS_API__: 'true',
+            __VUE_PROD_DEVTOOLS__: 'false'
+        });
     }
 
     /**

--- a/test/features/define.js
+++ b/test/features/define.js
@@ -1,0 +1,37 @@
+import test from 'ava';
+import assertions from '../helpers/assertions.js';
+
+import { mix } from '../helpers/mix.js';
+import webpack from '../helpers/webpack.js';
+
+test('Code is left alone where there are no replacements defined', async t => {
+    mix.js('test/fixtures/app/src/js/app.js', 'test/fixtures/app/dist/js');
+
+    await webpack.compile();
+
+    assertions.fileContains(
+        'test/fixtures/app/dist/js/app.js',
+        'console.log(__FEATURE_1__)',
+        t
+    );
+
+    assertions.fileContains(
+        'test/fixtures/app/dist/js/app.js',
+        'console.log(__FEATURE_2__)',
+        t
+    );
+});
+
+test('Code replacements can be defined', async t => {
+    mix.js('test/fixtures/app/src/js/app.js', 'test/fixtures/app/dist/js');
+    mix.define({
+        __FEATURE_1__: true,
+        __FEATURE_2__: () => '`auto`'
+    });
+
+    await webpack.compile();
+
+    assertions.fileContains('test/fixtures/app/dist/js/app.js', 'console.log(true)', t);
+
+    assertions.fileContains('test/fixtures/app/dist/js/app.js', 'console.log(`auto`)', t);
+});

--- a/test/features/vue3.js
+++ b/test/features/vue3.js
@@ -381,6 +381,41 @@ test('Vue-loader options via mix.vue', async t => {
     t.true(File.exists(`test/fixtures/app/dist/js/app.js`));
 });
 
+test('References to feature flags are replaced', async t => {
+    mix.vue({ version: 3 });
+    mix.js(`test/fixtures/app/src/vue/app-with-vue-and-css.js`, 'js/app.js');
+
+    await webpack.compile();
+
+    assert.fileDoesNotContain(
+        `test/fixtures/app/dist/js/app.js`,
+        'typeof __VUE_OPTIONS_API__',
+        t
+    );
+    assert.fileDoesNotContain(
+        `test/fixtures/app/dist/js/app.js`,
+        'typeof __VUE_PROD_DEVTOOLS__',
+        t
+    );
+});
+
+test('The default Vue feature flags can be overridden', async t => {
+    mix.vue({ version: 3 });
+    mix.js(`test/fixtures/app/src/vue/app-with-vue-and-css.js`, 'js/app.js');
+    mix.define({
+        __VUE_OPTIONS_API__: false
+    });
+
+    await webpack.compile();
+
+    // TODO: This relies on Vue internals — really this should be an integration test
+    assert.fileContains(
+        `test/fixtures/app/dist/js/app.js`,
+        'false ? 0 : _vue_shared__',
+        t
+    );
+});
+
 function compilerSpy() {
     const compiler = require('@vue/compiler-dom');
     let called = false;

--- a/test/fixtures/app/src/js/app.js
+++ b/test/fixtures/app/src/js/app.js
@@ -1,3 +1,7 @@
 import Vue from 'vue2';
 new Vue({ el: '#app' });
 alert('stub');
+// @ts-ignore
+console.log(__FEATURE_1__);
+// @ts-ignore
+console.log(__FEATURE_2__);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -75,6 +75,10 @@ export interface Api {
     dumpWebpackConfig(): Api;
 }
 
+type CodeValuePrimitive = undefined | null | string | number | bigint | boolean;
+type LazyCodeValue = () => CodeValuePrimitive;
+type CodeValue = CodeValuePrimitive | LazyCodeValue;
+
 // Assorted capabilities
 export interface Api {
     /** Add webpack-resolution aliases */
@@ -108,6 +112,9 @@ export interface Api {
 
     /** Disable only success notifications when mix builds assets */
     disableSuccessNotifications(): Api;
+
+    /** Replace variables in code with other values  */
+    define(definitions: Record<string, CodeValue>): Api;
 }
 
 // JS / Transpilation capabilities


### PR DESCRIPTION
Fixes #2905

By default we enable the options API and disable prod dev tools (this is what Vue 3 itself does by default).

You can override these by using the new `mix.define()` feature as long as its called *after* the call to mix.vue():
```js
mix.define({
  __VUE_OPTIONS_API__: false,
  __VUE_PROD_DEVTOOLS__: true,
});
```
