### PR TITLE
Allow changing the manifest name / path

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -213,6 +213,16 @@ module.exports = function (mix) {
         vue: {},
 
         /**
+         * The name / path to the mix manifest.
+         * The path is relative to the public path.
+         *
+         * Set to `false` to disable manifest generation.
+         *
+         * @type {string | false}
+         */
+        manifest: `mix-manifest.json`,
+
+        /**
          * Merge the given options with the current defaults.
          *
          * @param {object} options

--- a/test/unit/Manifest.js
+++ b/test/unit/Manifest.js
@@ -4,7 +4,9 @@ import path from 'path';
 
 import File from '../../src/File.js';
 import Manifest from '../../src/Manifest.js';
+import assertions from '../helpers/assertions.js';
 import { mix, Mix } from '../helpers/mix.js';
+import webpack from '../helpers/webpack.js';
 
 test.beforeEach(() => {
     Mix.manifest = new Manifest();
@@ -80,4 +82,49 @@ test('it sorts files on the underlying manifest object', t => {
         ['/path1.js', '/path2.js', '/path3.js', '/path4.js'].join(),
         Object.keys(manifest).join()
     );
+});
+
+test('A manifest is created by default ', async t => {
+    await webpack.compile();
+
+    assertions.fileExists('test/fixtures/app/dist/mix-manifest.json', t);
+});
+
+test('The name of the manifest can be changed', async t => {
+    mix.options({ manifest: 'manifest.json' });
+
+    await webpack.compile();
+
+    assertions.fileExists('test/fixtures/app/dist/manifest.json', t);
+    assertions.fileDoesNotExist('test/fixtures/app/dist/mix-manifest.json', t);
+});
+
+test('You can change the manfest path to a relative path', async t => {
+    mix.options({ manifest: '../manifest.json' });
+
+    await webpack.compile();
+
+    assertions.fileExists('test/fixtures/app/manifest.json', t);
+    assertions.fileDoesNotExist('test/fixtures/app/dist/mix-manifest.json', t);
+});
+
+test('Manifest generation can be disabled', async t => {
+    mix.options({
+        manifest: false
+    });
+
+    await webpack.compile();
+
+    assertions.fileDoesNotExist('test/fixtures/app/dist/mix-manifest.json', t);
+});
+
+test('Overwriting the manifest plugin with a custom name preserves old behavior', async t => {
+    mix.options({ manifest: 'foo.json' });
+    Mix.manifest.name = 'bar.json';
+
+    await webpack.compile();
+
+    assertions.fileDoesNotExist('test/fixtures/app/dist/mix-manifest.json', t);
+    assertions.fileDoesNotExist('test/fixtures/app/dist/foo.json', t);
+    assertions.fileExists('test/fixtures/app/dist/bar.json', t);
 });

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -47,6 +47,14 @@ interface MixConfig {
     publicPath?: string;
 
     /**
+     * The name / path to the mix manifest.
+     * The path is relative to the public path.
+     *
+     * Set to `false` to disable manifest generation.
+     **/
+    manifest?: string | false;
+
+    /**
      * The path for the runtime chunk (`manifest.js`).
      *
      * Defaults to being placed next to compiled JS files.


### PR DESCRIPTION
It is now possible to customize the name / path to the mix manifest. Additionally, if you do not want a manifest to be generated it may be disabled.

If you want to rename your file to `manifest.json` you can change the name by setting the `manifest` option:

```js
mix.options({ manifest: 'manifest.json' })
```

This also accepts relative paths which means the following are possible:

```js
mix.options({ manifest: 'build/mix-manifest.json' }) // ./public/build/mix-manifest.json
mix.options({ manifest: '../mix-manifest.json' }) // ./mix-manifest.json
```

Additionally, if you don't want to generate the manifest at all you can do so by setting the option to `false`:
```js
mix.options({ manifest: false })
```

cc @sbine