### PR TITLE
Fix File::parse() result

### DIFF
--- a/src/File.js
+++ b/src/File.js
@@ -314,7 +314,7 @@ class File {
             path: this.filePath,
             absolutePath: this.absolutePath,
             pathWithoutExt: path.join(parsed.dir, `${parsed.name}`),
-            isDir,
+            isDir: isDir,
             isFile: !isDir,
             name: parsed.name,
             ext: parsed.ext,


### PR DESCRIPTION
Unless I am wrong, 9c25ccf113269d4def05801b17feb370de944ecb unvolontarly alters the `File::parse()` result structure.

I just see this reading the code diff and do not know the impact.