### PR TITLE
Support ESM mix config

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -77,6 +77,10 @@ async function executeScript(cmd, opts, args = []) {
     ].join(' ');
 
     const scriptEnv = {
+        // Allow dynamic ESM imports
+        // This is an unfortunate workaround but it's the simplest way
+        // to get dynamic ESM imports & webpack-cli to play together
+        DISABLE_V8_COMPILE_CACHE: '1',
         NODE_ENV: env,
         MIX_FILE: opts.mixConfig
     };

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -67,7 +67,7 @@ async function executeScript(cmd, opts, args = []) {
     // containg spaces on Windows (yarn does)
     const configPath = path.relative(
         process.cwd(),
-        require.resolve('../setup/webpack.config.js')
+        require.resolve('../setup/webpack.config.mjs')
     );
 
     const script = [

--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -1,4 +1,5 @@
 const { assertSupportedNodeVersion } = require('../src/Engine');
+const Mix = require('../src/Mix');
 
 module.exports = async () => {
     // @ts-ignore
@@ -6,12 +7,20 @@ module.exports = async () => {
 
     assertSupportedNodeVersion();
 
-    const mix = require('../src/Mix').primary;
+    const mix = Mix.primary;
 
-    require(mix.paths.mix());
+    // Boot mix
+    await mix.boot();
 
+    // Load the user's mix config
+    await mix.load();
+
+    // Install any missing dependencies
     await mix.installDependencies();
+
+    // Start running
     await mix.init();
 
-    return mix.build();
+    // Turn everything into a config
+    return await mix.build();
 };

--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -1,26 +1,9 @@
 const { assertSupportedNodeVersion } = require('../src/Engine');
-const Mix = require('../src/Mix');
 
 module.exports = async () => {
-    // @ts-ignore
-    process.noDeprecation = true;
-
     assertSupportedNodeVersion();
 
-    const mix = Mix.primary;
+    const config = await import('./webpack.config.mjs');
 
-    // Boot mix
-    await mix.boot();
-
-    // Load the user's mix config
-    await mix.load();
-
-    // Install any missing dependencies
-    await mix.installDependencies();
-
-    // Start running
-    await mix.init();
-
-    // Turn everything into a config
-    return await mix.build();
+    return await config.default();
 };

--- a/setup/webpack.config.mjs
+++ b/setup/webpack.config.mjs
@@ -1,0 +1,23 @@
+import Mix from '../src/Mix.js';
+
+export default async function () {
+    // @ts-ignore
+    process.noDeprecation = true;
+
+    const mix = Mix.shared;
+
+    // Boot mix
+    await mix.boot();
+
+    // Load the user's mix config
+    await mix.load();
+
+    // Install any missing dependencies
+    await mix.installDependencies();
+
+    // Start running
+    await mix.init();
+
+    // Turn everything into a config
+    return await mix.build();
+}

--- a/src/ConfigLoader.mjs
+++ b/src/ConfigLoader.mjs
@@ -1,0 +1,80 @@
+import path from 'path';
+import { pathToFileURL, URL } from 'url';
+import { createRequire } from 'module';
+
+export class ConfigLoader {
+    /**
+     * @param {string} basePath
+     */
+    constructor(basePath) {
+        this.basePath = basePath;
+    }
+
+    /**
+     * Load the user's Mix config
+     */
+    async load() {
+        const configPath = await this.locate();
+
+        // TODO: Add test for this
+        if (configPath === null) {
+            throw new Error('Unable to find Mix config file');
+        }
+
+        // Pull in the user's mix config file
+        // An ESM import here allows a user's mix config
+        // to be an ESM module and use top-level await
+        return await import(configPath);
+    }
+
+    /**
+     * Determine the path to the user's webpack.mix.js file.
+     *
+     * @internal
+     * @returns {Promise<URL|null>}
+     */
+    async locate() {
+        for (const location of await this.possibleLocations()) {
+            if (location) {
+                return pathToFileURL(location);
+            }
+        }
+
+        return null;
+    }
+
+    async possibleLocations() {
+        return await Promise.all(
+            this.possibleNames().map(filepath => this.find(filepath))
+        );
+    }
+
+    possibleNames() {
+        if (process.env.MIX_FILE) {
+            return [
+                process.env.MIX_FILE,
+                `${process.env.MIX_FILE}.mjs`,
+                `${process.env.MIX_FILE}.cjs`,
+                `${process.env.MIX_FILE}.js`
+            ];
+        }
+
+        return ['webpack.mix.mjs', 'webpack.mix.cjs', 'webpack.mix.js'];
+    }
+
+    /**
+     * TODO: Should we use `mix.resolve` here so it can be mocked?
+     *
+     * @param {string} name
+     * @returns {Promise<string|null>}
+     */
+    async find(name) {
+        try {
+            const require = createRequire(import.meta.url);
+
+            return require.resolve(path.resolve(this.basePath, name));
+        } catch (err) {
+            return null;
+        }
+    }
+}

--- a/src/Paths.js
+++ b/src/Paths.js
@@ -25,25 +25,6 @@ class Paths {
     }
 
     /**
-     * Determine the path to the user's webpack.mix.js file.
-     */
-    mix() {
-        const path = this.root(
-            process.env && process.env.MIX_FILE ? process.env.MIX_FILE : 'webpack.mix'
-        );
-
-        try {
-            require.resolve(`${path}.cjs`);
-
-            return `${path}.cjs`;
-        } catch (err) {
-            //
-        }
-
-        return path;
-    }
-
-    /**
      * Determine the project root.
      *
      * @param {string} [append]

--- a/src/index.js
+++ b/src/index.js
@@ -23,3 +23,13 @@ module.exports = global.Mix.api;
 
 // Allow ESM: import mix from 'laravel-mix'
 module.exports.default = global.Mix.api;
+
+/**
+ * Define typescript config helper for ESM & CJS:
+ *
+ * const { defineConfig } = import('laravel-mix')
+ * import { defineConfig } from 'laravel-mix'
+ *
+ * @type {import('laravel-mix').defineConfig}
+ */
+module.exports.defineConfig = fn => fn;

--- a/src/index.js
+++ b/src/index.js
@@ -13,8 +13,4 @@ require('./helpers');
  |
  */
 
-let mix = Mix.primary;
-
-mix.boot();
-
-module.exports = mix.api;
+module.exports = Mix.shared.api;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,3 @@
-const Mix = require('./Mix');
-
-require('./helpers');
-
 /*
  |--------------------------------------------------------------------------
  | Welcome to Laravel Mix!
@@ -13,4 +9,17 @@ require('./helpers');
  |
  */
 
-module.exports = Mix.shared.api;
+if (!global.Mix) {
+    throw new Error(
+        'Importing / requiring laravel-mix should only happen when building your code.'
+    );
+}
+
+// TODO: Remove in next major version — none of these are used by mix itself
+require('./helpers');
+
+// Allow CJS: const mix = import('laravel-mix')
+module.exports = global.Mix.api;
+
+// Allow ESM: import mix from 'laravel-mix'
+module.exports.default = global.Mix.api;

--- a/test/helpers/cli.js
+++ b/test/helpers/cli.js
@@ -7,6 +7,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 /**
  * @typedef {object} CliResult
  * @property {Error|null} error
+ * @property {number} elapsed
  * @property {number} code
  * @property {string} stdout
  * @property {string} stderr
@@ -83,6 +84,8 @@ export function cli(opts) {
             stderr: ''
         };
 
+        const start = process.hrtime.bigint();
+
         const child = spawn(cmd, {
             shell: true,
             cwd,
@@ -102,6 +105,7 @@ export function cli(opts) {
 
         child.on('error', err => (result.error = err));
         child.on('close', (code, signal) => {
+            result.elapsed = Number(process.hrtime.bigint() - start) / 1_000_000;
             result.code = code || 0;
             result.signal = signal;
         });

--- a/test/integration/cli.js
+++ b/test/integration/cli.js
@@ -35,6 +35,11 @@ test('An empty mix file results in a successful build', async t => {
 
 const configFiles = {
     CJS: 'webpack.mix',
+    'CJS with replaced export': 'webpack.mix.fn.raw',
+    'CJS with default export': 'webpack.mix.fn.default',
+
+    ESM: 'webpack.mix.esm',
+    'ESM with default export': 'webpack.mix.esm.fn.raw'
 };
 
 for (const [testName, fileName] of Object.entries(configFiles)) {

--- a/test/integration/cli.js
+++ b/test/integration/cli.js
@@ -2,7 +2,6 @@ import test from 'ava';
 import path from 'path';
 import request from 'supertest';
 import { fileURLToPath } from 'url';
-
 import { cli } from '../helpers/cli.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -11,13 +10,6 @@ const mix = cli({
     testing: false,
     env: { NODE_ENV: 'development' },
     cwd: path.resolve(__dirname, './fixture')
-});
-
-test('It can run the CLI', async t => {
-    const { error, stderr } = await mix();
-
-    t.is('', stderr);
-    t.is(null, error);
 });
 
 test('Missing config files result in non-zero exit code', async t => {
@@ -32,12 +24,27 @@ test('Webpack errors result in non-zero exit code', async t => {
     t.not(0, code);
 });
 
-test('An empty mix file results in a successful build with a warning', async t => {
+test('An empty mix file results in a successful build', async t => {
     const { code, stderr } = await mix(['--mix-config=webpack.mix.empty']);
 
+    // TODO: This should show a warning that nothing is being compiled
+
     t.is(0, code);
-    t.regex(stderr, /not set up correctly/i);
+    t.is(stderr, '');
 });
+
+const configFiles = {
+    CJS: 'webpack.mix',
+};
+
+for (const [testName, fileName] of Object.entries(configFiles)) {
+    test(`Run CLI with config: ${testName}`, async t => {
+        const { code, stderr } = await mix([`--mix-config=${fileName}`]);
+
+        t.is(0, code);
+        t.is('', stderr);
+    });
+}
 
 /*
 test.serial('it removes the hot reloading file when the process is finished', async t => {

--- a/test/integration/cli.js
+++ b/test/integration/cli.js
@@ -37,9 +37,11 @@ const configFiles = {
     CJS: 'webpack.mix',
     'CJS with replaced export': 'webpack.mix.fn.raw',
     'CJS with default export': 'webpack.mix.fn.default',
+    'CJS with default export + defineConfig': 'webpack.mix.fn.define',
 
     ESM: 'webpack.mix.esm',
-    'ESM with default export': 'webpack.mix.esm.fn.raw'
+    'ESM with default export': 'webpack.mix.esm.fn.raw',
+    'ESM with default export + defineConfig': 'webpack.mix.esm.fn.define'
 };
 
 for (const [testName, fileName] of Object.entries(configFiles)) {

--- a/test/integration/fixture/webpack.mix.esm.fn.define.mjs
+++ b/test/integration/fixture/webpack.mix.esm.fn.define.mjs
@@ -1,0 +1,5 @@
+import { defineConfig } from '../../../src/index.js';
+
+export default defineConfig(mix => {
+    mix.setPublicPath('public');
+});

--- a/test/integration/fixture/webpack.mix.esm.fn.raw.mjs
+++ b/test/integration/fixture/webpack.mix.esm.fn.raw.mjs
@@ -1,0 +1,6 @@
+/**
+ * @param {import('laravel-mix').Api} mix
+ */
+export default function (mix) {
+    mix.setPublicPath('public');
+}

--- a/test/integration/fixture/webpack.mix.esm.mjs
+++ b/test/integration/fixture/webpack.mix.esm.mjs
@@ -1,0 +1,3 @@
+import mix from '../../../src/index.js';
+
+mix.setPublicPath('public');

--- a/test/integration/fixture/webpack.mix.fn.default.cjs
+++ b/test/integration/fixture/webpack.mix.fn.default.cjs
@@ -1,0 +1,3 @@
+module.exports = mix => {
+    mix.setPublicPath('public');
+};

--- a/test/integration/fixture/webpack.mix.fn.define.cjs
+++ b/test/integration/fixture/webpack.mix.fn.define.cjs
@@ -1,0 +1,5 @@
+const { defineConfig } = require('../../../src/index.js');
+
+module.exports.default = defineConfig(mix => {
+    mix.setPublicPath('public');
+});

--- a/test/integration/fixture/webpack.mix.fn.raw.cjs
+++ b/test/integration/fixture/webpack.mix.fn.raw.cjs
@@ -1,0 +1,6 @@
+/**
+ * @param {import('laravel-mix').Api} mix
+ */
+module.exports = function (mix) {
+    mix.setPublicPath('public');
+};

--- a/test/unit/cli.js
+++ b/test/unit/cli.js
@@ -22,21 +22,33 @@ test('it calls webpack in development mode', async t => {
     const result = await mix();
 
     result.assertScript(t, `webpack --progress --config="${configPath}"`);
-    result.assertEnv(t, { MIX_FILE: 'webpack.mix', NODE_ENV: 'development' });
+    result.assertEnv(t, {
+        DISABLE_V8_COMPILE_CACHE: '1',
+        MIX_FILE: 'webpack.mix',
+        NODE_ENV: 'development'
+    });
 });
 
 test('it calls webpack in production mode', async t => {
     const result = await mix(['--production']);
 
     result.assertScript(t, `webpack --progress --config="${configPath}"`);
-    result.assertEnv(t, { MIX_FILE: 'webpack.mix', NODE_ENV: 'production' });
+    result.assertEnv(t, {
+        DISABLE_V8_COMPILE_CACHE: '1',
+        MIX_FILE: 'webpack.mix',
+        NODE_ENV: 'production'
+    });
 });
 
 test('it calls webpack with watch mode', async t => {
     const result = await mix(['watch']);
 
     result.assertScript(t, `webpack --watch --progress --config="${configPath}"`);
-    result.assertEnv(t, { MIX_FILE: 'webpack.mix', NODE_ENV: 'development' });
+    result.assertEnv(t, {
+        DISABLE_V8_COMPILE_CACHE: '1',
+        MIX_FILE: 'webpack.mix',
+        NODE_ENV: 'development'
+    });
 });
 
 test('it calls webpack with watch mode using polling', async t => {
@@ -46,21 +58,33 @@ test('it calls webpack with watch mode using polling', async t => {
         t,
         `webpack --watch --progress --config="${configPath}" --watch-poll`
     );
-    result.assertEnv(t, { MIX_FILE: 'webpack.mix', NODE_ENV: 'development' });
+    result.assertEnv(t, {
+        DISABLE_V8_COMPILE_CACHE: '1',
+        MIX_FILE: 'webpack.mix',
+        NODE_ENV: 'development'
+    });
 });
 
 test('it calls webpack with hot reloading', async t => {
     const result = await mix(['watch', '--hot']);
 
     result.assertScript(t, `webpack serve --hot --config="${configPath}"`);
-    result.assertEnv(t, { MIX_FILE: 'webpack.mix', NODE_ENV: 'development' });
+    result.assertEnv(t, {
+        DISABLE_V8_COMPILE_CACHE: '1',
+        MIX_FILE: 'webpack.mix',
+        NODE_ENV: 'development'
+    });
 });
 
 test('it calls webpack with hot reloading using polling', async t => {
     const result = await mix(['watch', '--hot', '--', '--watch-poll']);
 
     result.assertScript(t, `webpack serve --hot --config="${configPath}" --watch-poll`);
-    result.assertEnv(t, { MIX_FILE: 'webpack.mix', NODE_ENV: 'development' });
+    result.assertEnv(t, {
+        DISABLE_V8_COMPILE_CACHE: '1',
+        MIX_FILE: 'webpack.mix',
+        NODE_ENV: 'development'
+    });
 });
 
 test('it calls webpack with quoted key value pair command arguments', async t => {
@@ -70,7 +94,11 @@ test('it calls webpack with quoted key value pair command arguments', async t =>
         t,
         `webpack --progress --config="${configPath}" --env foo="bar baz" foo="bar=baz"`
     );
-    result.assertEnv(t, { MIX_FILE: 'webpack.mix', NODE_ENV: 'development' });
+    result.assertEnv(t, {
+        DISABLE_V8_COMPILE_CACHE: '1',
+        MIX_FILE: 'webpack.mix',
+        NODE_ENV: 'development'
+    });
 });
 
 test.serial('it calls webpack with custom node_env', async t => {
@@ -83,7 +111,11 @@ test.serial('it calls webpack with custom node_env', async t => {
     process.env.NODE_ENV = oldEnv;
 
     result.assertScript(t, `webpack --progress --config="${configPath}"`);
-    result.assertEnv(t, { MIX_FILE: 'webpack.mix', NODE_ENV: 'foobar' });
+    result.assertEnv(t, {
+        DISABLE_V8_COMPILE_CACHE: '1',
+        MIX_FILE: 'webpack.mix',
+        NODE_ENV: 'foobar'
+    });
 });
 
 test.serial('it disables progress reporting when not using a terminal', async t => {
@@ -94,12 +126,20 @@ test.serial('it disables progress reporting when not using a terminal', async t 
     delete process.env.IS_TTY;
 
     result.assertScript(t, `webpack --config="${configPath}"`);
-    result.assertEnv(t, { MIX_FILE: 'webpack.mix', NODE_ENV: 'development' });
+    result.assertEnv(t, {
+        DISABLE_V8_COMPILE_CACHE: '1',
+        MIX_FILE: 'webpack.mix',
+        NODE_ENV: 'development'
+    });
 });
 
 test('it disables progress reporting when requested', async t => {
     const result = await mix(['--no-progress']);
 
     result.assertScript(t, `webpack --config="${configPath}"`);
-    result.assertEnv(t, { MIX_FILE: 'webpack.mix', NODE_ENV: 'development' });
+    result.assertEnv(t, {
+        DISABLE_V8_COMPILE_CACHE: '1',
+        MIX_FILE: 'webpack.mix',
+        NODE_ENV: 'development'
+    });
 });

--- a/test/unit/cli.js
+++ b/test/unit/cli.js
@@ -14,7 +14,7 @@ test.before(() => {
 
     configPath = path.relative(
         process.cwd(),
-        require.resolve('../../setup/webpack.config.js')
+        require.resolve('../../setup/webpack.config.mjs')
     );
 });
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -300,9 +300,16 @@ interface Api {
     vue(config?: VueConfig): Api;
 }
 
+interface ApiCallback {
+    (api: Api): void | Promise<void>;
+}
+
+// declare function doesn't work right here
+declare type defineConfig = (fn: ApiCallback) => ApiCallback;
+
 declare const exports: Api;
 declare namespace exports {
-    export { Api, Component, ReactConfig, VueConfig };
+    export { defineConfig, Api, Component, ReactConfig, VueConfig };
 }
 
 declare global {


### PR DESCRIPTION
# This is planned for v6.1

This adds support for a few big features:
1. An ESM mix config — you can now use import/export with `type: "module"` or the extension `.mjs`.
2. A default exported function. In the absence of TLA support you can use and export a default function which can optionally be asynchronous that defines the config. It gets passed the `mix` variable/API that is exported from the package normally.
3. Along with item 2, this has enabled a `defineConfig` helper. This kind of thing has started to become a bit more common and it aids typing as well.