### PR TITLE
Fix TypeScript docs, we should use .ts file for entry file

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -40,7 +40,7 @@ Of course, you'll still want to make any appropriate TypeScript-specific tweaks,
 Enabling TypeScript compilation within your Vue single file components is a cinch. Begin by updating your `webpack.mix.js` file to specify that you wish to compile TypeScript while also enabling support for Vue single file components.
 
 ```js
-mix.ts('resources/js/app.js', 'public/js').vue();
+mix.ts('resources/js/app.ts', 'public/js').vue();
 ```
 
 Next, update your single file component(s) to allow TypeScript to infer types.


### PR DESCRIPTION
Otherwise, running `npm run hot` will give the following error:

```
[@vue/compiler-sfc] compileTemplate now requires the `id` option.`.
```


Related issue: https://github.com/laravel-mix/laravel-mix/issues/3184
