### PR TITLE
Fix pattern for matching chuckHashes

### DIFF
--- a/src/Manifest.js
+++ b/src/Manifest.js
@@ -42,7 +42,7 @@ class Manifest {
     add(filePath) {
         filePath = this.normalizePath(filePath);
 
-        let original = filePath.replace(/\?id=\w{20}/, '');
+        let original = filePath.replace(/\?id=(\w{20}|\w{16})/, '');
 
         this.manifest[original] = filePath;
 

--- a/src/Manifest.js
+++ b/src/Manifest.js
@@ -42,7 +42,7 @@ class Manifest {
     add(filePath) {
         filePath = this.normalizePath(filePath);
 
-        let original = filePath.replace(/\?id=(\w{20}|\w{16})/, '');
+        let original = filePath.replace(/\?id=\w+/, '');
 
         this.manifest[original] = filePath;
 


### PR DESCRIPTION
Updating from version 6.0.19 to 6.0.41 breaks our entire application. The Problem:

Somewhere along the way between minor versions 19 and 41, through the Webpack dependency in Laravel mix I assume, the chunkHashes for JS-files in our project were shortened to 16 characters instead of 20 like before. For `app.js` and `manifest.js` however, the chunkHashes remain 20 characters long. It appears to me that Laravel Mix is able to cope with this, as long as I let the manifest handle all the mapping of what modules to fetch. However, if I want to prefetch JavaScript-files, or just declare them in my template (which for us drastically reduces load times), such as:

````
<link rel="prefetch" href="{{ mix('js/direction-maps.js') }}">
<script async src="{{ mix('js/detail-product-list.js') }}"></script>
````

I get the following error:

```
Exception - Unable to locate Mix file: /js/**js-file-name**.js. (View: /Users/tsd/PhpstormProjects/project-name/resources/views/components/head/prefetching.blade.php)
Unable to locate Mix file: /js/**js-file-name**.js.
```

Since the chunkHashes are sometimes 16 characters long, and sometimes 20 like before, this would be my suggested fix.