### PR TITLE
Add a Potential Fix to a Bug in the HMR Server

### DIFF
--- a/docs/hot-module-replacement.md
+++ b/docs/hot-module-replacement.md
@@ -1,6 +1,7 @@
 # Hot Module Replacement
 
 -   [Basic Usage in Laravel](#basic-usage-in-laravel.md)
+-   [My Browser Cannot Connect To The HMR Server](#my-browser-cannot-connect-to-the-hmr-server.md)
 
 Where available, Laravel Mix provides seamless support for hot module replacement.
 
@@ -38,3 +39,26 @@ However, it can be a burden - and risk - to manually change this URL back and fo
 ```
 
 With this adjustment, Laravel will do the work for you. If you run `npx mix watch --hot` to enable hot reloading, the function will prepend the necessary `http://localhost:8080` base url. If, instead, you run `npx mix` or `npx mix watch`, it'll reference your domain as the base.
+
+### My Browser Cannot Connect To The HMR Server
+
+Sometimes, when you are using the default port `8080` for the Node server, the Node server might be unresponsive and cannot serve the bundle files. You might see the error `net::ERR_EMPTY_RESPONSE` in your browser's console when trying to access the resources via port `8080`.
+
+![Screenshot of the browser console reporting error net::ERR_EMPTY_RESPONSE when fetching the bundle files from the Node server](https://camo.githubusercontent.com/f34799c55c825e9762e4b62b383c3e2a88f75838d5cc3f4779d72c1859d8816a/68747470733a2f2f696d6775722e636f6d2f485068627976312e706e67)
+
+In addition, Laravel Mix might not report the error, `failure to bind to port 8080`, in the CLI.
+
+A potential solution is to manually provide the port. You can do this by appending this code below in your `webpack.mix.js`. 
+
+```js
+mix.options({
+    hmrOptions: {
+        host: 'localhost',
+        port: 4206
+    }
+});
+```
+
+However, if the Node server is still unresponsive, try editing the port in the configuration and try again.
+
+Keep in mind that this solution to an unresponsive Node server will only work for **some people, not everyone**.


### PR DESCRIPTION
This fix to help those in the future who face this odd behavior where Webpack will fail to report that it cannot bind to port `8080`.

I added instructions and extra information to provide a potential solution to this issue.