### PR TITLE
Use webpack asset modules

### DIFF
--- a/src/builder/webpack-default.js
+++ b/src/builder/webpack-default.js
@@ -20,6 +20,7 @@ module.exports = function (mix) {
         entry: {},
 
         output: {
+            assetModuleFilename: '[name][ext]?[hash]',
             chunkFilename: '[name].[hash:5].js'
         },
 

--- a/src/builder/webpack-rules.js
+++ b/src/builder/webpack-rules.js
@@ -27,7 +27,7 @@ module.exports = function (mix) {
                     const relativePath = pathData.filename;
 
                     if (!/node_modules|bower_components/.test(relativePath)) {
-                        return mix.config.fileLoaderDirs.images + '/[name].[ext]?[hash]';
+                        return mix.config.fileLoaderDirs.images + '/[name][ext]?[hash]';
                     }
 
                     return (
@@ -41,7 +41,8 @@ module.exports = function (mix) {
                             ) +
                         '?[hash]'
                     );
-                }
+                },
+                publicPath: mix.config.resourceRoot
             },
             use: [
                 {
@@ -61,7 +62,7 @@ module.exports = function (mix) {
                 const relativePath = pathData.filename;
 
                 if (!/node_modules|bower_components/.test(relativePath)) {
-                    return mix.config.fileLoaderDirs.fonts + '/[name].[ext]?[hash]';
+                    return mix.config.fileLoaderDirs.fonts + '/[name][ext]?[hash]';
                 }
 
                 return (
@@ -75,7 +76,8 @@ module.exports = function (mix) {
                         ) +
                     '?[hash]'
                 );
-            }
+            },
+            publicPath: mix.config.resourceRoot
         }
     });
 
@@ -84,7 +86,8 @@ module.exports = function (mix) {
         test: /\.(cur|ani)$/,
         type: 'asset/resource',
         generator: {
-            filename: mix.config.resourceRoot + '/[name].[ext]?[hash]'
+            filename: '[name][ext]?[hash]',
+            publicPath: mix.config.resourceRoot
         }
     });
 

--- a/src/builder/webpack-rules.js
+++ b/src/builder/webpack-rules.js
@@ -21,37 +21,29 @@ module.exports = function (mix) {
         rules.push({
             // only include svg that doesn't have font in the path or file name by using negative lookahead
             test: /(\.(png|jpe?g|gif|webp|avif)$|^((?!font).)*\.svg$)/,
-            use: [
-                {
-                    loader: mix.resolve('file-loader'),
-                    options: {
-                        /**
-                         * @param {string} path
-                         */
-                        name: path => {
-                            if (!/node_modules|bower_components/.test(path)) {
-                                return (
-                                    mix.config.fileLoaderDirs.images +
-                                    '/[name].[ext]?[hash]'
-                                );
-                            }
+            type: 'asset/resource',
+            generator: {
+                filename: pathData => {
+                    const relativePath = pathData.filename;
 
-                            return (
-                                mix.config.fileLoaderDirs.images +
-                                '/vendor/' +
-                                path
-                                    .replace(/\\/g, '/')
-                                    .replace(
-                                        /((.*(node_modules|bower_components))|images|image|img|assets)\//g,
-                                        ''
-                                    ) +
-                                '?[hash]'
-                            );
-                        },
-                        publicPath: mix.config.resourceRoot
+                    if (!/node_modules|bower_components/.test(relativePath)) {
+                        return mix.config.fileLoaderDirs.images + '/[name].[ext]?[hash]';
                     }
-                },
 
+                    return (
+                        mix.config.fileLoaderDirs.images +
+                        '/vendor/' +
+                        relativePath
+                            .replace(/\\/g, '/')
+                            .replace(
+                                /((.*(node_modules|bower_components))|images|image|img|assets)\//g,
+                                ''
+                            ) +
+                        '?[hash]'
+                    );
+                }
+            },
+            use: [
                 {
                     loader: mix.resolve('img-loader'),
                     options: mix.config.imgLoaderOptions || {}
@@ -63,50 +55,37 @@ module.exports = function (mix) {
     // Add support for loading fonts.
     rules.push({
         test: /(\.(woff2?|ttf|eot|otf)$|font.*\.svg$)/,
-        use: [
-            {
-                loader: mix.resolve('file-loader'),
-                options: {
-                    /**
-                     * @param {string} path
-                     */
-                    name: path => {
-                        if (!/node_modules|bower_components/.test(path)) {
-                            return (
-                                mix.config.fileLoaderDirs.fonts + '/[name].[ext]?[hash]'
-                            );
-                        }
+        type: 'asset/resource',
+        generator: {
+            filename: pathData => {
+                const relativePath = pathData.filename;
 
-                        return (
-                            mix.config.fileLoaderDirs.fonts +
-                            '/vendor/' +
-                            path
-                                .replace(/\\/g, '/')
-                                .replace(
-                                    /((.*(node_modules|bower_components))|fonts|font|assets)\//g,
-                                    ''
-                                ) +
-                            '?[hash]'
-                        );
-                    },
-                    publicPath: mix.config.resourceRoot
+                if (!/node_modules|bower_components/.test(relativePath)) {
+                    return mix.config.fileLoaderDirs.fonts + '/[name].[ext]?[hash]';
                 }
+
+                return (
+                    mix.config.fileLoaderDirs.fonts +
+                    '/vendor/' +
+                    relativePath
+                        .replace(/\\/g, '/')
+                        .replace(
+                            /((.*(node_modules|bower_components))|fonts|font|assets)\//g,
+                            ''
+                        ) +
+                    '?[hash]'
+                );
             }
-        ]
+        }
     });
 
     // Add support for loading cursor files.
     rules.push({
         test: /\.(cur|ani)$/,
-        use: [
-            {
-                loader: mix.resolve('file-loader'),
-                options: {
-                    name: '[name].[ext]?[hash]',
-                    publicPath: mix.config.resourceRoot
-                }
-            }
-        ]
+        type: 'asset/resource',
+        generator: {
+            filename: mix.config.resourceRoot + '/[name].[ext]?[hash]'
+        }
     });
 
     return rules;

--- a/src/builder/webpack-rules.js
+++ b/src/builder/webpack-rules.js
@@ -17,78 +17,175 @@ module.exports = function (mix) {
     });
 
     if (mix.config.imgLoaderOptions) {
+        const imageRuleOptions = mix.config.assetModules
+            ? {
+                  type: 'asset/resource',
+                  generator: {
+                      filename: pathData => {
+                          const relativePath = pathData.filename;
+
+                          if (!/node_modules|bower_components/.test(relativePath)) {
+                              return mix.config.assetDirs.images + '/[name][ext]?[hash]';
+                          }
+
+                          return (
+                              mix.config.assetDirs.images +
+                              '/vendor/' +
+                              relativePath
+                                  .replace(/\\/g, '/')
+                                  .replace(
+                                      /((.*(node_modules|bower_components))|images|image|img|assets)\//g,
+                                      ''
+                                  ) +
+                              '?[hash]'
+                          );
+                      },
+                      publicPath: mix.config.resourceRoot
+                  },
+                  use: [
+                      {
+                          loader: mix.resolve('img-loader'),
+                          options: mix.config.imgLoaderOptions || {}
+                      }
+                  ]
+              }
+            : {
+                  use: [
+                      {
+                          loader: mix.resolve('file-loader'),
+                          options: {
+                              /**
+                               * @param {string} path
+                               */
+                              name: path => {
+                                  if (!/node_modules|bower_components/.test(path)) {
+                                      return (
+                                          mix.config.fileLoaderDirs.images +
+                                          '/[name].[ext]?[hash]'
+                                      );
+                                  }
+
+                                  return (
+                                      mix.config.fileLoaderDirs.images +
+                                      '/vendor/' +
+                                      path
+                                          .replace(/\\/g, '/')
+                                          .replace(
+                                              /((.*(node_modules|bower_components))|images|image|img|assets)\//g,
+                                              ''
+                                          ) +
+                                      '?[hash]'
+                                  );
+                              },
+                              publicPath: mix.config.resourceRoot
+                          }
+                      },
+
+                      {
+                          loader: mix.resolve('img-loader'),
+                          options: mix.config.imgLoaderOptions || {}
+                      }
+                  ]
+              };
+
         // Add support for loading images.
         rules.push({
             // only include svg that doesn't have font in the path or file name by using negative lookahead
             test: /(\.(png|jpe?g|gif|webp|avif)$|^((?!font).)*\.svg$)/,
-            type: 'asset/resource',
-            generator: {
-                filename: pathData => {
-                    const relativePath = pathData.filename;
-
-                    if (!/node_modules|bower_components/.test(relativePath)) {
-                        return mix.config.fileLoaderDirs.images + '/[name][ext]?[hash]';
-                    }
-
-                    return (
-                        mix.config.fileLoaderDirs.images +
-                        '/vendor/' +
-                        relativePath
-                            .replace(/\\/g, '/')
-                            .replace(
-                                /((.*(node_modules|bower_components))|images|image|img|assets)\//g,
-                                ''
-                            ) +
-                        '?[hash]'
-                    );
-                },
-                publicPath: mix.config.resourceRoot
-            },
-            use: [
-                {
-                    loader: mix.resolve('img-loader'),
-                    options: mix.config.imgLoaderOptions || {}
-                }
-            ]
+            ...imageRuleOptions
         });
     }
+
+    const fontRuleOptions = mix.config.assetModules
+        ? {
+              type: 'asset/resource',
+              generator: {
+                  filename: pathData => {
+                      const relativePath = pathData.filename;
+
+                      if (!/node_modules|bower_components/.test(relativePath)) {
+                          return mix.config.fileLoaderDirs.fonts + '/[name][ext]?[hash]';
+                      }
+
+                      return (
+                          mix.config.fileLoaderDirs.fonts +
+                          '/vendor/' +
+                          relativePath
+                              .replace(/\\/g, '/')
+                              .replace(
+                                  /((.*(node_modules|bower_components))|fonts|font|assets)\//g,
+                                  ''
+                              ) +
+                          '?[hash]'
+                      );
+                  },
+                  publicPath: mix.config.resourceRoot
+              }
+          }
+        : {
+              use: [
+                  {
+                      loader: mix.resolve('file-loader'),
+                      options: {
+                          /**
+                           * @param {string} path
+                           */
+                          name: path => {
+                              if (!/node_modules|bower_components/.test(path)) {
+                                  return (
+                                      mix.config.fileLoaderDirs.fonts +
+                                      '/[name].[ext]?[hash]'
+                                  );
+                              }
+
+                              return (
+                                  mix.config.fileLoaderDirs.fonts +
+                                  '/vendor/' +
+                                  path
+                                      .replace(/\\/g, '/')
+                                      .replace(
+                                          /((.*(node_modules|bower_components))|fonts|font|assets)\//g,
+                                          ''
+                                      ) +
+                                  '?[hash]'
+                              );
+                          },
+                          publicPath: mix.config.resourceRoot
+                      }
+                  }
+              ]
+          };
 
     // Add support for loading fonts.
     rules.push({
         test: /(\.(woff2?|ttf|eot|otf)$|font.*\.svg$)/,
-        type: 'asset/resource',
-        generator: {
-            filename: pathData => {
-                const relativePath = pathData.filename;
-
-                if (!/node_modules|bower_components/.test(relativePath)) {
-                    return mix.config.fileLoaderDirs.fonts + '/[name][ext]?[hash]';
-                }
-
-                return (
-                    mix.config.fileLoaderDirs.fonts +
-                    '/vendor/' +
-                    relativePath
-                        .replace(/\\/g, '/')
-                        .replace(
-                            /((.*(node_modules|bower_components))|fonts|font|assets)\//g,
-                            ''
-                        ) +
-                    '?[hash]'
-                );
-            },
-            publicPath: mix.config.resourceRoot
-        }
+        ...fontRuleOptions
     });
+
+    const cursorRuleOptions = mix.config.assetModules
+        ? {
+              type: 'asset/resource',
+              generator: {
+                  filename: '[name][ext]?[hash]',
+                  publicPath: mix.config.resourceRoot
+              }
+          }
+        : {
+              use: [
+                  {
+                      loader: mix.resolve('file-loader'),
+                      options: {
+                          name: '[name].[ext]?[hash]',
+                          publicPath: mix.config.resourceRoot
+                      }
+                  }
+              ]
+          };
 
     // Add support for loading cursor files.
     rules.push({
         test: /\.(cur|ani)$/,
-        type: 'asset/resource',
-        generator: {
-            filename: '[name][ext]?[hash]',
-            publicPath: mix.config.resourceRoot
-        }
+        ...cursorRuleOptions
     });
 
     return rules;

--- a/src/config.js
+++ b/src/config.js
@@ -120,6 +120,7 @@ module.exports = function (mix) {
          * File Loader directory defaults.
          *
          * @deprecated Use `assetModules: true` and `assetDirs` instead
+         * @type {{images: string, fonts: string}}
          */
         fileLoaderDirs: {
             images: 'images',
@@ -135,6 +136,8 @@ module.exports = function (mix) {
 
         /**
          * Asset directory defaults.
+         *
+         * @type {{images: string, fonts: string}}
          */
         assetDirs: {
             images: 'images',

--- a/src/config.js
+++ b/src/config.js
@@ -106,7 +106,7 @@ module.exports = function (mix) {
          * Image Loader defaults.
          * See: https://github.com/thetalecrafter/img-loader#options
          *
-         * @type {Boolean|Object}
+         * @type {Object}
          */
         imgLoaderOptions: {
             enabled: true,
@@ -118,8 +118,25 @@ module.exports = function (mix) {
 
         /**
          * File Loader directory defaults.
+         *
+         * @deprecated Use `assetModules: true` and `assetDirs` instead
          */
         fileLoaderDirs: {
+            images: 'images',
+            fonts: 'fonts'
+        },
+
+        /**
+         * Use Webpack asset modules instead of File Loader.
+         *
+         * @type {Boolean}
+         */
+        assetModules: false,
+
+        /**
+         * Asset directory defaults.
+         */
+        assetDirs: {
             images: 'images',
             fonts: 'fonts'
         },

--- a/test/features/mix.js
+++ b/test/features/mix.js
@@ -73,3 +73,30 @@ test.serial(
         assert(t).file(`test/fixtures/app/dist/images/awesome.svg`).absent();
     }
 );
+
+test.serial(
+    'it resolves image- and font-urls and distinguishes between them even if we deal with svg (using legacy file-loader)',
+    async t => {
+        const { mix, fs, assert, webpack } = context(t);
+
+        mix.options({ assetModules: false });
+
+        // Given we have a sass file that refers to ../font.svg, ../font/awesome.svg and to ../img/img.svg
+        mix.sass(`test/fixtures/app/src/sass/font-and-image.scss`, 'css');
+        // When we compile it
+        await webpack.compile();
+
+        // Then we expect the css to be built
+        assert(t).file(`test/fixtures/app/dist/css/font-and-image.css`).exists();
+        // Along with the referred image in the images folder
+        assert(t).file(`test/fixtures/app/dist/images/img.svg`).exists();
+        // And the referred fonts in the fonts folder
+        assert(t).file(`test/fixtures/app/dist/fonts/font.svg`).exists();
+        assert(t).file(`test/fixtures/app/dist/fonts/awesome.svg`).exists();
+        // And we expect the image NOT to be in the fonts folder:
+        assert(t).file(`test/fixtures/app/dist/fonts/img.svg`).absent();
+        // And the fonts NOT to be in the image folder
+        assert(t).file(`test/fixtures/app/dist/images/font.svg`).absent();
+        assert(t).file(`test/fixtures/app/dist/images/awesome.svg`).absent();
+    }
+);

--- a/test/features/setResourceRoot.js
+++ b/test/features/setResourceRoot.js
@@ -24,7 +24,7 @@ test.serial('mix.setResourceRoot() rewrites processed asset urls', async t => {
     assert(t).file(`test/fixtures/app/dist/css/app-and-image.css`).matchesCss(`
         .app {
             color: red;
-            background-image: url(https://www.example.com/images/img.svg?66162863e7583212a5d4fd6cdc2426ed);
+            background-image: url(https://www.example.com/images/img.svg?1538a77b2687265b);
         }
     `);
 });

--- a/test/features/setResourceRoot.js
+++ b/test/features/setResourceRoot.js
@@ -28,3 +28,27 @@ test.serial('mix.setResourceRoot() rewrites processed asset urls', async t => {
         }
     `);
 });
+
+test.serial(
+    'mix.setResourceRoot() rewrites processed asset urls (using legacy file-loader)',
+    async t => {
+        const { mix, webpack, assert } = context(t);
+
+        mix.options({ assetModules: false });
+
+        mix.setResourceRoot('https://www.example.com/');
+        mix.postCss(`test/fixtures/app/src/css/app-and-image.css`, 'css');
+
+        await webpack.compile();
+
+        assert(t).file(`test/fixtures/app/dist/css/app-and-image.css`).exists();
+        assert(t).file(`test/fixtures/app/dist/images/img.svg`).exists();
+
+        assert(t).file(`test/fixtures/app/dist/css/app-and-image.css`).matchesCss(`
+        .app {
+            color: red;
+            background-image: url(https://www.example.com/images/img.svg?66162863e7583212a5d4fd6cdc2426ed);
+        }
+    `);
+    }
+);

--- a/test/helpers/TestContext.js
+++ b/test/helpers/TestContext.js
@@ -44,15 +44,19 @@ export class TestContext {
         await this.Mix.boot();
         await this.disk.setup();
 
-        const publicPath = this.disk.join(this.publicPath)
+        const publicPath = this.disk.join(this.publicPath);
 
         // Set the output path to the appropriate directory in the temporary disk
-        await fsx.mkdir(publicPath, { mode: 0o777, recursive: true })
+        await fsx.mkdir(publicPath, { mode: 0o777, recursive: true });
         this.mix.setPublicPath(this.publicPath);
 
         // We also disable autoprefixer
         // Under profiling loading autoprefixer takes 2.5s
         this.mix.options({ autoprefixer: false });
+
+        // We also enable assetModules
+        // TODO: Remove in Mix 7 -- this should be the default then
+        this.mix.options({ assetModules: true });
     }
 
     teardown() {
@@ -100,8 +104,8 @@ export class TestContext {
 export const context = (t, metadata = undefined) => {
     if (t.context instanceof TestContext) {
         t.context.t = t;
-   } else {
-        t.context = new TestContext(t)
+    } else {
+        t.context = new TestContext(t);
     }
 
     Object.assign(t.context.metadata, metadata || {});

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -89,11 +89,24 @@ interface MixConfig {
         svgo?: SvgoConfig;
     };
 
-    /** File Loader directory defaults. */
+    /**
+     * File Loader directory defaults.
+     *
+     * @deprecated Use `assetModules: true` and `assetDirs` instead
+     **/
     fileLoaderDirs?: {
         images?: string;
         fonts?: string;
     };
+
+    /** Asset directory defaults. */
+    assetDirs?: {
+        images?: string;
+        fonts?: string;
+    };
+
+    /** Use Webpack asset modules instead of File Loader. */
+    assetModules?: boolean;
 
     /**
      * Determine if CSS relative url()s should be resolved by webpack.


### PR DESCRIPTION
Replace deprecated `file-loader` with Webpack asset modules, as described in https://webpack.js.org/guides/asset-modules/.

Fixes #2914 and fixes #3249 for my setup.