### PR TITLE
File copying fixes

### DIFF
--- a/src/FileCollection.js
+++ b/src/FileCollection.js
@@ -1,9 +1,10 @@
 let concat = require('concat');
 let path = require('path');
-let fs = require('fs');
+let fs = require('fs-extra');
 let babel = require('@babel/core');
 let glob = require('glob');
 let _ = require('lodash');
+let { promisify } = require('util');
 let Log = require('./Log');
 let File = require('./File');
 
@@ -73,52 +74,70 @@ class FileCollection {
     }
 
     /**
+     *
+     * @param {string|File|(string|File)[]} src
+     */
+    async normalizeSourceFiles(src) {
+        // 1. Always work with an array of sources
+        let sources = Array.isArray(src) ? src : [src]
+
+        // 2. Ensure we're working with File objects
+        let files = sources.map(file => {
+            return typeof file === 'string'
+                ? new File(file)
+                : file
+        })
+
+        let globAsync = promisify(glob)
+
+        // 3. Expand globs
+        let groups = await Promise.all(files.map(async file => {
+            if (! file.contains('*')) {
+                return [file]
+            }
+
+            let files = await globAsync(file.path(), { nodir: true });
+
+            if (!files.length) {
+                Log.feedback(`Notice: The ${file.path()} search produced no matches.`);
+            }
+
+            return files.map(filepath => new File(filepath))
+        }))
+
+        return groups.flat()
+    }
+
+    /**
      * Copy the src files to the given destination.
      *
      * @param {File} destination
      * @param {string[]|File} [src]
-     * @return {void|string}
+     * @return {Promise<void>}
      */
-    copyTo(destination, src = this.files) {
-        this.assets = this.assets || [];
+    async copyTo(destination, src = this.files) {
+        this.assets = this.assets || []
 
-        this.destination = destination;
+        let sourceFiles = await this.normalizeSourceFiles(src)
 
-        if (Array.isArray(src)) {
-            src.forEach(file => this.copyTo(destination, new File(file)));
+        // Copy an array of files to the destination file/directory
+        // file -> file: no change in destination file name
+        // directory -> file: this is an error
+        // file -> directory: change name
+        // directory -> directory: don't change name
+        await Promise.all(sourceFiles.map(async file => {
+            const dest = file.isFile() && destination.isDirectory()
+                ? destination.append(file.name())
+                : destination
 
-            return;
-        }
-
-        if (src.isDirectory()) {
-            src.copyTo(destination.path());
-
-            this.assets = fs.readdirSync(src.path()).map(file => {
-                return new File(path.resolve(destination.path(), file));
-            });
-
-            return;
-        }
-
-        if (src.contains('*')) {
-            let files = glob.sync(src.path(), { nodir: true });
-
-            if (!files.length) {
-                Log.feedback(`Notice: The ${src.path()} search produced no matches.`);
-            }
-
-            return this.copyTo(destination, files);
-        }
+            await file.copyToAsync(dest.path());
+        }))
 
         if (destination.isDirectory()) {
-            destination = destination.append(src.name());
+            this.assets = await destination.listContentsAsync()
+        } else {
+            this.assets = [destination]
         }
-
-        src.copyTo(destination.path());
-
-        this.assets = this.assets.concat(destination);
-
-        return destination.path();
     }
 
     get mix() {

--- a/src/tasks/CopyFilesTask.js
+++ b/src/tasks/CopyFilesTask.js
@@ -11,12 +11,12 @@ class CopyFilesTask extends Task {
     /**
      * Run the task.
      */
-    run() {
+    async run() {
         let copy = this.data;
 
         this.files = new FileCollection(copy.from);
 
-        this.files.copyTo(copy.to);
+        await this.files.copyTo(copy.to);
 
         this.assets = this.files.assets;
     }
@@ -26,7 +26,7 @@ class CopyFilesTask extends Task {
      *
      * @param {string} updatedFile
      */
-    onChange(updatedFile) {
+    async onChange(updatedFile) {
         let destination = this.data.to;
 
         // If we're copying a src directory recursively, we have to calculate
@@ -39,7 +39,7 @@ class CopyFilesTask extends Task {
 
         Log.feedback(`Copying ${updatedFile} to ${destination.path()}`);
 
-        this.files.copyTo(destination, new File(updatedFile));
+        await this.files.copyTo(destination, new File(updatedFile));
     }
 }
 

--- a/src/webpackPlugins/CustomTasksPlugin.js
+++ b/src/webpackPlugins/CustomTasksPlugin.js
@@ -36,18 +36,6 @@ class CustomTasksPlugin {
     }
 
     /**
-     * Execute the task.
-     *
-     * @param {import("../tasks/Task")} task
-     * @param {import("webpack").Stats} stats
-     */
-    async runTask(task, stats) {
-        await Promise.resolve(task.run());
-
-        await Promise.allSettled(task.assets.map(asset => this.addAsset(asset, stats)));
-    }
-
-    /**
      * Add asset to the webpack stats.
      *
      * @param {import("../File")} asset
@@ -76,14 +64,17 @@ class CustomTasksPlugin {
      * Execute potentially asynchronous tasks sequentially.
      *
      * @param stats
-     * @param index
      */
-    runTasks(stats, index = 0) {
-        if (index === this.mix.tasks.length) return Promise.resolve();
+    async runTasks(stats) {
+        let assets = []
 
-        const task = this.mix.tasks[index];
+        for (const task of this.mix.tasks) {
+            await Promise.resolve(task.run());
 
-        return this.runTask(task, stats).then(() => this.runTasks(stats, index + 1));
+            assets.push(...task.assets)
+        }
+
+        await Promise.allSettled(assets.map(asset => this.addAsset(asset, stats)));
     }
 
     /**
@@ -115,9 +106,9 @@ class CustomTasksPlugin {
      * Version all files that are present in the manifest.
      */
     applyVersioning() {
-        collect(this.mix.manifest.get()).each((value, key) =>
+        for (const [key, value] of Object.entries(this.mix.manifest.get())) {
             this.mix.manifest.hash(key)
-        );
+        }
     }
 }
 

--- a/src/webpackPlugins/CustomTasksPlugin.js
+++ b/src/webpackPlugins/CustomTasksPlugin.js
@@ -92,6 +92,7 @@ class CustomTasksPlugin {
     async minifyAssets() {
         const assets = collect(this.mix.tasks)
             .where('constructor.name', '!==', 'VersionFilesTask')
+            .where('constructor.name', '!==', 'CopyFilesTask')
             .flatMap(({ assets }) => assets);
 
         const tasks = assets.map(async asset => {

--- a/test/features/combine.js
+++ b/test/features/combine.js
@@ -92,7 +92,7 @@ test.serial(
 
         assert()
             .file('test/fixtures/app/dist/js/combined-scripts.js')
-            .matchesCss('alert("foo1"),alert("foo2");');
+            .matchesCss("alert('foo1');alert('foo2');");
     }
 );
 

--- a/test/features/copy.js
+++ b/test/features/copy.js
@@ -58,6 +58,8 @@ test.serial('It can copy directories and handle versioning.', async t => {
     assert().manifestEquals({
         '/copy/file-1.txt': '/copy/file-1.txt',
         '/copy/file-2.txt': '/copy/file-2.txt',
+        '/copy/dir-1/file-1.txt': '/copy/dir-1/file-1.txt',
+        '/copy/dir-1/file-2.txt': '/copy/dir-1/file-2.txt',
         '/js/app.js': '/js/app.js'
     });
 });

--- a/test/helpers/assertions.js
+++ b/test/helpers/assertions.js
@@ -236,7 +236,6 @@ export function assert(t) {
          * Verify that the mix manifest is the same as `expected`
          *
          * @param {Record<string, string>} expected
-         * @param {import("ava").Assertions} t
          */
         manifestEquals(expected) {
             let manifest = JSON.parse(

--- a/test/unit/File.js
+++ b/test/unit/File.js
@@ -201,7 +201,7 @@ test('it can copy a file to a new location', async t => {
     const file = new File(filePath).write('.foo {}');
     const copiedPath = disk.join('new.css');
 
-    file.copyTo(copiedPath);
+    await file.copyTo(copiedPath);
 
     assert().file(copiedPath).exists();
     assert().file(filePath).contains('.foo {}\n');


### PR DESCRIPTION
This does a few things:
1. Prevents `copy(…)` and `copyDirectory(…)` from minifying assets. This is a super weird behavior. This is theoretically a breaking change but because it's minified it shouldn't affect things. Double minifying can actually cause issues so this should be a net win.
2. Puts directory contents into the mix manifest when using `copy`/`copyDirectory` to copy a directory of files. (passersby tip: They're literally the same function — you can just use `copy` and it works the same)
3. Vastly simplifies the code around file/directory copying and makes it fully asynchronous. This should speed up copying of large directories.
4. ***STILL TODO*** ensure copying works properly with `setPublicPath` and dotfiles
5. ***STILL TODO*** Verify copying files outside the public path doesn't break hashing

I still need to verify tests around glob handling.

Note not all the below are fixed yet but I am aiming to fix them before merging this PR.

Fixes #3255 (done)
Fixes #3085 (done)
Fixes #3068 (done)
Fixes #2412 (done)

Edit: After some investigation some of the following may require technically breaking changes (some may not):

~#3233 (todo)~
~#3171 (todo)~
~#2953 (todo)~
~#2857 (todo)~
~#1772 (todo)~
