### PR TITLE
Log exceptions to console instead of silently failing

### DIFF
--- a/src/Log.js
+++ b/src/Log.js
@@ -129,12 +129,16 @@ class Log {
     /**
      * Determine if the given message was logged.
      *
-     * @param  {string} message
+     * @param  {string|string[]} messages
      */
-    static received(message) {
-        let result = Log.fakedLogs.some(log => log.includes(message));
+    static received(messages) {
+        messages = Array.isArray(messages) ? messages : [messages];
 
-        Log.restore();
+        let result = messages.every(message =>
+            this.fakedLogs.some(log => log.includes(message))
+        );
+
+        this.restore();
 
         return result;
     }

--- a/src/VueVersion.js
+++ b/src/VueVersion.js
@@ -29,7 +29,7 @@ class VueVersion {
             try {
                 return this.detect(require(this.mix.resolve('vue')).version);
             } catch (e) {
-                console.error(e);
+                this.mix.logger.error(`${e}`);
                 this.fail();
             }
         }

--- a/src/VueVersion.js
+++ b/src/VueVersion.js
@@ -29,6 +29,7 @@ class VueVersion {
             try {
                 return this.detect(require(this.mix.resolve('vue')).version);
             } catch (e) {
+                console.error(e);
                 this.fail();
             }
         }

--- a/test/unit/VueVersion.js
+++ b/test/unit/VueVersion.js
@@ -38,7 +38,12 @@ test('it aborts if Vue is not installed', async t => {
 
     t.throws(() => vueVersion.detect());
 
-    t.true(mix.logger.received(`couldn't find a supported version of Vue`));
+    t.true(
+        mix.logger.received([
+            `Cannot find module 'vue'`,
+            `couldn't find a supported version of Vue`
+        ])
+    );
 });
 
 test('it aborts if an unsupported Vue version is provided', t => {


### PR DESCRIPTION
Had a debugging session today when Mix stopped working and reported:

Before:
```
We couldn't find a supported version of Vue in your project. Please ensure that it's installed (npm install vue).
 
[webpack-cli] Error: Unable to detect vue version
    at VueVersion.fail ([...]/node_modules/laravel-mix/src/VueVersion.js:54:15)
    at VueVersion.detect ([...]/node_modules/laravel-mix/src/VueVersion.js:33:22)
    at Vue.register ([...]/node_modules/laravel-mix/src/components/Vue.js:39:53)
    at Object.components.<computed> [as vue] ([...]/node_modules/laravel-mix/src/components/ComponentRegistrar.js:163:49)
    at Object.<anonymous> ([...]/webpack.mix.js:15:6)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Module.require (internal/modules/cjs/loader.js:887:19)
```

Turns out that it was a syntax error, because I was still on a machine running Node 12 (yes, it's old, but it's also still the default package version in latest Ubuntu for example).

Anyway, dug into the Mix code and realized that when one of the try/catch blocks catch, it only reports the above error instead of the root cause / exception message.

Thought I'd add in a simple `console.error` call for now.

After:
```
[...]/node_modules/@vue/compiler-core/dist/compiler-core.cjs.js:3261
            if (grandparent?.source) {
                            ^

SyntaxError: Unexpected token '.'
    at wrapSafe (internal/modules/cjs/loader.js:915:16)
    at Module._compile (internal/modules/cjs/loader.js:963:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Module.require (internal/modules/cjs/loader.js:887:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> ([...]/node_modules/@vue/compiler-core/index.js:6:20)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)

We couldn't find a supported version of Vue in your project. Please ensure that it's installed (npm install vue).

[...]
```

Solution to root cause: upgrade Node version, e.g. to 16.x or newer