### PR TITLE
Fix Yarn 3 running mix always requires webpack-cli

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -147,7 +147,7 @@ async function executeScript(cmd, opts, args = []) {
  */
 function commandScript(cmd, opts) {
     const showProgress = isTTY() && opts.progress;
-    const script = ['webpack'];
+    const script = ['webpack-cli'];
 
     if (cmd === 'build' && showProgress) {
         script.push('--progress');


### PR DESCRIPTION
Yesterday I followed the steps to migrate my existing projects to Yarn 3 and all are working with a few workarounds, but not the ones based in Laravel mix. This is why:

![image](https://user-images.githubusercontent.com/2331052/169645872-ab9a69bb-86b3-4f5a-be53-5236fdd7d31b.png)

And what I did was something they recommended here: https://github.com/webpack/webpack-cli/issues/1434#issuecomment-656887013

Also possibly fixes problem of #3237? But I'm not so sure...