### PR TITLE
Fix Webpack 'vue-loader' Module not found error

### DIFF
--- a/src/components/Vue.js
+++ b/src/components/Vue.js
@@ -64,7 +64,7 @@ module.exports = class Vue extends Component {
 
         let dependencies = [
             this.version === 2 ? 'vue-template-compiler' : '@vue/compiler-sfc',
-            this.version === 2 ? 'vue-loader@^15.9.7' : 'vue-loader@^16.2.0'
+            this.version === 2 ? 'vue-loader@^15.9.8' : 'vue-loader@^16.2.0'
         ];
 
         if (this.options.extractStyles && this.options.globalStyles) {


### PR DESCRIPTION
Every time that I upgrade one of my older projects to Laravel Mix 6 I have run into this MODULE_NOT_FOUND bug due to version 15.9.7 of `vue-loader` being installed. This bumps the default version of `vue-loader` for Vue 2 to 15.9.8.

Version 15.9.7 has a bug where Webpack cannot find the module:
https://github.com/vuejs/vue-loader/issues/1859

Version 15.9.8 fixes that:
https://github.com/vuejs/vue-loader/releases?q=v15.9.8&expanded=true