### PR TITLE
Update tests to run on active Node versions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -20,7 +20,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node-version: [12.x, 16.x, 17.x, 18.x]
+                node-version: [14.x, 16.x, 18.x, 19.x]
                 os: [ubuntu-latest, windows-latest]
 
         steps:
@@ -36,6 +36,4 @@ jobs:
               run: npm ci --legacy-peer-deps
 
             - name: Run Tests
-              env:
-                  NODE_OPTIONS: ${{ matrix.node-version == '17.x' && '--openssl-legacy-provider' || '' }}
               run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,10 +24,10 @@ jobs:
                 os: [ubuntu-latest, windows-latest]
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v2
+              uses: actions/setup-node@v3
               with:
                   cache: 'npm'
                   node-version: ${{ matrix.node-version }}

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -225,10 +225,6 @@ function isTTY() {
 }
 
 function requiresLegacyOpenSSLProvider() {
-    if (!process.version.startsWith('v17.') && !process.version.startsWith('v18.')) {
-        return false;
-    }
-
     try {
         require('crypto').createHash('md4').update('test').digest('hex');
 


### PR DESCRIPTION
Node v12 and v17 have reached EOL; Node v19 has been released.

Note: it might be desirable to also update the required Node.js version in `package.json` in a future version.